### PR TITLE
Dont auto-discover butler packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,11 @@
         "laravel": {
             "providers": [
                 "Butler\\Service\\ServiceProvider"
+            ],
+            "dont-discover": [
+                "glesys/butler-auth",
+                "glesys/butler-graphql",
+                "glesys/butler-guru"
             ]
         }
     },

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -164,6 +164,9 @@ return [
         /*
          * Package Service Providers...
          */
+        Butler\Auth\ServiceProvider::class,
+        Butler\Graphql\ServiceProvider::class,
+        Butler\Guru\ServiceProvider::class,
 
         /*
          * Application Service Providers...


### PR DESCRIPTION
Because `butler-auth`, `butler-graphql` and `butler-guru` depends on `butler-service` they need to be loaded after `butler-service`.