### PR TITLE
Fix timezone issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+
+- Support overriding timezone.
 
 ## [0.2.5] - 2020-04-29
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -10,9 +10,11 @@ class ServiceProvider extends BaseServiceProvider
     {
         $this->mergeApplicationConfig();
 
-        $this->registerBaseProviders();
-
         $this->configureExtraConfig();
+
+        $this->configureTimezone();
+
+        $this->registerBaseProviders();
 
         $this->registerExtraAliases();
 
@@ -51,13 +53,6 @@ class ServiceProvider extends BaseServiceProvider
         }
     }
 
-    protected function registerBaseProviders()
-    {
-        if (config('bugsnag.api_key', false)) {
-            $this->app->register(\Bugsnag\BugsnagLaravel\BugsnagServiceProvider::class);
-        }
-    }
-
     protected function configureExtraConfig()
     {
         if ($this->app->configurationIsCached()) {
@@ -66,6 +61,22 @@ class ServiceProvider extends BaseServiceProvider
 
         foreach (config('butler.service.extra.config', []) as $key => $value) {
             config()->set($key, $value);
+        }
+    }
+
+    protected function configureTimezone()
+    {
+        // NOTE: To be able to override the timezone config we need to call
+        // `date_default_timezone_set()`. Laravel already does this in the
+        // LoadConfiguration bootstrapper but at that time we haven't yet merged
+        // the config overrides.
+        date_default_timezone_set(config('app.timezone'));
+    }
+
+    protected function registerBaseProviders()
+    {
+        if (config('bugsnag.api_key', false)) {
+            $this->app->register(\Bugsnag\BugsnagLaravel\BugsnagServiceProvider::class);
         }
     }
 

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -4,6 +4,7 @@ namespace Butler\Service\Tests;
 
 use Butler\Service\Tests\Health\TestChecker;
 use GrahamCampbell\TestBenchCore\ServiceProviderTrait;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 
 class ServiceProviderTest extends TestCase
@@ -46,6 +47,12 @@ class ServiceProviderTest extends TestCase
         $this->assertEquals('foobar', config('session.table'));
     }
 
+    public function test_can_override_timezone()
+    {
+        $this->assertEquals('Europe/Stockholm', config('app.timezone'));
+        $this->assertEquals('Europe/Stockholm', Carbon::now()->getTimezone());
+    }
+
     /**
      * @dataProvider butlerServiceConfigProvider
      */
@@ -62,7 +69,10 @@ class ServiceProviderTest extends TestCase
             ['butler.service.routes.graphql', '/graphql'],
             ['butler.service.routes.health', '/health'],
             ['butler.service.health.checks', [TestCheck::class]],
-            ['butler.service.extra.config', ['foo' => 'bar']],
+            ['butler.service.extra.config', [
+                'app.timezone' => 'Europe/Stockholm',
+                'foo' => 'bar'
+            ]],
             ['butler.service.extra.aliases', ['Foobar' => Cache::class]],
             ['butler.service.extra.providers', [FoobarServiceProvider::class]],
         ];

--- a/tests/config/butler.php
+++ b/tests/config/butler.php
@@ -49,6 +49,7 @@ return [
 
         'extra' => [
             'config' => [
+                'app.timezone' => 'Europe/Stockholm',
                 'foo' => 'bar',
             ],
             'aliases' => [


### PR DESCRIPTION
> NOTE: To be able to override the timezone config we need to call `date_default_timezone_set()`. Laravel already does this in the LoadConfiguration bootstrapper but at that time we haven't yet merged the config overrides.
