### PR TITLE
Dont require 'default' directory for default database migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+- `MigratesDatabases` trait now supports default database migrations directly in `database/migrations`.
 
 ## [0.2.7] - 2020-05-05
 

--- a/src/Testing/Concerns/MigratesDatabases.php
+++ b/src/Testing/Concerns/MigratesDatabases.php
@@ -9,9 +9,13 @@ trait MigratesDatabases
 {
     public function migrateDatabase(string $database = 'default'): void
     {
+        if ($database === 'default' && ! is_dir(database_path('migrations/default'))) {
+            $path = 'database/migrations';
+        }
+
         $this->artisan('migrate:fresh', [
             '--database' => $database,
-            '--path' => "database/migrations/{$database}",
+            '--path' => $path ?? "database/migrations/{$database}",
             '--seeder' => Str::studly("{$database}DatabaseSeeder"),
         ]);
 


### PR DESCRIPTION
This allows migrations for the default database to be stored directly in `database/migrations` (like a normal Laravel app) instead of `database/migrations/default`.

This should make `\Illuminate\Foundation\Testing\RefreshDatabase` work with butler-service.