### PR TITLE
Dont require 'DefaultDatabaseSeeder' for default database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 - `MigratesDatabases` trait now supports default database migrations directly in `database/migrations`.
+- `MigratesDatabases` trait now supports default database seeder (`DatabaseSeeder.php`) for the default database connection.
 
 ## [0.2.7] - 2020-05-05
 

--- a/src/Testing/Concerns/MigratesDatabases.php
+++ b/src/Testing/Concerns/MigratesDatabases.php
@@ -9,16 +9,30 @@ trait MigratesDatabases
 {
     public function migrateDatabase(string $database = 'default'): void
     {
-        if ($database === 'default' && ! is_dir(database_path('migrations/default'))) {
-            $path = 'database/migrations';
-        }
-
         $this->artisan('migrate:fresh', [
             '--database' => $database,
-            '--path' => $path ?? "database/migrations/{$database}",
-            '--seeder' => Str::studly("{$database}DatabaseSeeder"),
+            '--path' => $this->migrationsPath($database),
+            '--seeder' => $this->seederName($database),
         ]);
 
         $this->app[Kernel::class]->setArtisan(null);
+    }
+
+    private function migrationsPath(string $database): string
+    {
+        if ($database === 'default' && ! is_dir(database_path('migrations/default'))) {
+            return 'database/migrations';
+        }
+
+        return "database/migrations/{$database}";
+    }
+
+    private function seederName(string $database): string
+    {
+        if ($database === 'default' && ! is_file(database_path('seeds/DefaultDatabaseSeeder'))) {
+            return 'DatabaseSeeder';
+        }
+
+        return Str::studly("{$database}DatabaseSeeder");
     }
 }


### PR DESCRIPTION
This allows the use of the default `DatabaseSeeder.php` (like a normal Laravel app) if `DefaultDatabaseSeeder.php` dont exist.