### PR TITLE
Return unknown state for Redis health check when redis host is undefined

### DIFF
--- a/src/Health/Checks/Redis.php
+++ b/src/Health/Checks/Redis.php
@@ -18,9 +18,11 @@ class Redis extends Check
             return Result::unknown('Redis extension not enabled.');
         }
 
-        try {
-            $host = config('database.redis.default.host');
+        if (! $host = config('database.redis.default.host')) {
+            return Result::unknown('Redis host undefined.');
+        }
 
+        try {
             RedisClient::set(
                 $key = 'butler-service-health-check',
                 $string = Str::random()

--- a/tests/Health/RedisCheckTest.php
+++ b/tests/Health/RedisCheckTest.php
@@ -11,12 +11,27 @@ class RedisCheckTest extends TestCase
     public function test_unknown_when_redis_extension_is_not_loaded()
     {
         if (extension_loaded('redis')) {
-            return $this->assertTrue(true);
+            $this->markTestSkipped();
         }
 
         $result = (new Redis())->run();
 
         $this->assertEquals('Redis extension not enabled.', $result->message);
+        $this->assertEquals(Result::UNKNOWN, $result->state);
+        $this->assertNull($result->value());
+    }
+
+    public function test_unknown_when_redis_host_is_undefined()
+    {
+        if (! extension_loaded('redis')) {
+            $this->markTestSkipped();
+        }
+
+        config(['database.redis.default.host' => null]);
+
+        $result = (new Redis())->run();
+
+        $this->assertEquals('Redis host undefined.', $result->message);
         $this->assertEquals(Result::UNKNOWN, $result->state);
         $this->assertNull($result->value());
     }


### PR DESCRIPTION
Prevents the "Could not connect to redis on ..." when redis is not used in the service.