### PR TITLE
Use correlation id from butler-audit when logging to Graylog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+- Use the correlation id from butler-audit when logging to graylog to enable tracing requests/executions into graylog.
 
 ## [0.6.1] - 2021-02-18
 

--- a/tests/Unit/GraylogLoggerFactoryTest.php
+++ b/tests/Unit/GraylogLoggerFactoryTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Butler\Service\Tests\Unit;
+
+use Butler\Audit\Facades\Auditor;
+use Butler\Service\Logging\GraylogLoggerFactory;
+use Butler\Service\Tests\TestCase;
+use Gelf\Message;
+use Gelf\Transport\UdpTransport;
+use Mockery;
+
+class GraylogLoggerFactoryTest extends TestCase
+{
+    public function test_correctly_uses_configuration_and_correlation_id_from_container()
+    {
+        Auditor::correlationId('example-correlation-id');
+
+        app()->bind(UdpTransport::class, function () {
+            $transport = Mockery::mock(UdpTransport::class);
+            $transport->expects()->send(
+                Mockery::on(function (Message $message) {
+                    return $message->getShortMessage() === 'Testing'
+                        && $message->getAdditional('trace_id') === 'example-correlation-id'
+                        && $message->getAdditional('service') === 'butler-service';
+                })
+            );
+            return $transport;
+        });
+
+        $config = [
+            'name' => 'butler-service',
+            'name_key' => 'service',
+            'host' => '127.0.0.1',
+            'port' => 12201,
+        ];
+
+        $factory = new GraylogLoggerFactory($config);
+        $logger = $factory($config);
+        $logger->info('Testing');
+    }
+}


### PR DESCRIPTION
Use the correlation-id published by butler-audit when logging
to graylog and rename the extra field to `correlation_id` to
follow the same naming convention.

This change is made to be able to trace requests between systems.