### PR TITLE
Extend bus dispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+- Custom `Bus\Dispatcher` to support the new job trait `WithCorrelationId`.
+
 ## [0.5.0] - 2021-01-21
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ See [butler-guru](https://github.com/glesys/butler-guru).
 
 See [butler-audit](https://github.com/glesys/butler-audit).
 
+### Queued jobs and correlation ID
+
+The trait `WithCorrelationId` can be used on queable jobs that needs the same correlation id as the request.
+
 ## Testing
 
 ```shell

--- a/src/Bus/Dispatcher.php
+++ b/src/Bus/Dispatcher.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Butler\Service\Bus;
+
+use Butler\Audit\Facades\Auditor;
+use Illuminate\Bus\Dispatcher as BaseDispatcher;
+use Illuminate\Contracts\Container\Container;
+
+class Dispatcher extends BaseDispatcher
+{
+    public function __construct(Container $app, BaseDispatcher $dispatcher)
+    {
+        parent::__construct($app, $dispatcher->queueResolver);
+    }
+
+    public function dispatchToQueue($command)
+    {
+        if (in_array(WithCorrelationId::class, class_uses_recursive($command))) {
+            $command->correlationId = Auditor::correlationId();
+        }
+
+        return parent::dispatchToQueue($command);
+    }
+}

--- a/src/Bus/WithCorrelationId.php
+++ b/src/Bus/WithCorrelationId.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Butler\Service\Bus;
+
+trait WithCorrelationId
+{
+    public $correlationId;
+}

--- a/tests/Bus/DispatcherTest.php
+++ b/tests/Bus/DispatcherTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Butler\Service\Tests\Bus;
+
+use Butler\Service\Tests\TestCase;
+use Illuminate\Support\Facades\Queue;
+use Butler\Audit\Facades\Auditor;
+
+class DispatcherTest extends TestCase
+{
+    public function test_it_sets_correlation_id_for_job_using_WithCorrelationId_trait()
+    {
+        Auditor::fake();
+        Queue::fake();
+
+        Auditor::correlationId('a-correlation-id');
+
+        dispatch(new JobWithCorrelationId());
+
+        Queue::assertPushed(function (JobWithCorrelationId $job) {
+            return $job->correlationId === 'a-correlation-id';
+        });
+    }
+
+    public function test_it_does_not_set_correlation_id_only_for_job_not_using_WithCorrelationId_trait()
+    {
+        Auditor::fake();
+        Queue::fake();
+
+        dispatch(new JobWithoutCorrelationId());
+
+        Queue::assertPushed(function (JobWithoutCorrelationId $job) {
+            return ! property_exists($job, 'correlationId');
+        });
+    }
+}

--- a/tests/Bus/JobWithCorrelationId.php
+++ b/tests/Bus/JobWithCorrelationId.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Butler\Service\Tests\Bus;
+
+use Butler\Service\Bus\WithCorrelationId;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class JobWithCorrelationId implements ShouldQueue
+{
+    use Queueable;
+    use WithCorrelationId;
+
+    public function handle()
+    {
+        return true;
+    }
+}

--- a/tests/Bus/JobWithoutCorrelationId.php
+++ b/tests/Bus/JobWithoutCorrelationId.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Butler\Service\Tests\Bus;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class JobWithoutCorrelationId implements ShouldQueue
+{
+    use Queueable;
+
+    public function handle()
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
tldr; When a job with `WithCorrelationId` trait is queued, store the current correlation-id and use it when the job is processed.