### PR TITLE
Add consumers endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `/consumers` endpoint
+- Consumers is returned from `/health` if authorized.
 
 ### Changed
 - **BREAKING**: Use [token abilities](https://laravel.com/docs/8.x/sanctum#token-abilities) to authorize GraphQL operations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `/consumers` endpoint
+
 ### Changed
 - **BREAKING**: Use [token abilities](https://laravel.com/docs/8.x/sanctum#token-abilities) to authorize GraphQL operations.
 

--- a/config/butler.php
+++ b/config/butler.php
@@ -41,6 +41,7 @@ return [
             'front' => '/',
             'graphql' => '/graphql',
             'health' => '/health',
+            'consumers' => '/consumers',
         ],
 
         'health' => [

--- a/src/Http/Controllers/ConsumersController.php
+++ b/src/Http/Controllers/ConsumersController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Butler\Service\Http\Controllers;
+
+use Butler\Service\Models\Consumer;
+
+class ConsumersController extends Controller
+{
+    public function __invoke()
+    {
+        return Consumer::select('name')->get();
+    }
+}

--- a/src/Models/Consumer.php
+++ b/src/Models/Consumer.php
@@ -5,10 +5,12 @@ namespace Butler\Service\Models;
 use Butler\Service\Database\Model;
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
+use Illuminate\Foundation\Auth\Access\Authorizable;
 use Laravel\Sanctum\HasApiTokens;
 
 class Consumer extends Model implements AuthenticatableContract
 {
     use Authenticatable;
+    use Authorizable;
     use HasApiTokens;
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -227,5 +227,9 @@ class ServiceProvider extends BaseServiceProvider
         Gate::define('graphql', function (Consumer $consumer, $operation) {
             return $operation ? $consumer->tokenCan($operation) : false;
         });
+
+        Gate::define('view-consumers', function (Consumer $consumer) {
+            return $consumer->tokenCan('view-consumers');
+        });
     }
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -1,8 +1,9 @@
 <?php
 
+use Butler\Service\Http\Controllers\ConsumersController;
+use Butler\Service\Http\Controllers\FrontController;
 use Butler\Service\Http\Controllers\GraphqlController;
 use Butler\Service\Http\Controllers\HealthController;
-use Butler\Service\Http\Controllers\FrontController;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware('web')->group(function () {
@@ -22,4 +23,9 @@ Route::middleware(['api', 'auth'])->group(function () {
         config('butler.service.routes.graphql', '/graphql'),
         GraphqlController::class
     )->name('graphql');
+
+    Route::get(
+        config('butler.service.routes.consumers', '/consumers'),
+        ConsumersController::class
+    )->middleware('can:view-consumers')->name('consumers');
 });

--- a/tests/Feature/ConsumersTest.php
+++ b/tests/Feature/ConsumersTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Butler\Service\Tests\Feature;
+
+use Butler\Service\Models\Consumer;
+use Butler\Service\Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+
+class ConsumersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_requires_authentication()
+    {
+        $this->getJson(route('consumers'))->assertStatus(401);
+    }
+
+    public function test_it_requires_authorization()
+    {
+        Sanctum::actingAs(new Consumer(), ['some-ability']);
+
+        $this->getJson(route('consumers'))->assertForbidden();
+    }
+
+    public function test_it_returns_json()
+    {
+        Consumer::create(['name' => 'consumer-1']);
+
+        Sanctum::actingAs(new Consumer(), ['*']);
+
+        $this->getJson(route('consumers'))
+            ->assertOk()
+            ->assertExactJson([
+                ['name' => 'consumer-1'],
+            ]);
+    }
+}

--- a/tests/Feature/HealthTest.php
+++ b/tests/Feature/HealthTest.php
@@ -4,11 +4,16 @@
 
 namespace Butler\Service\Tests\Feature;
 
+use Butler\Service\Models\Consumer;
 use Butler\Service\Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Testing\Fluent\AssertableJson;
+use Laravel\Sanctum\Sanctum;
 
 class HealthTest extends TestCase
 {
+    use RefreshDatabase;
+
     public function test_it_returns_json()
     {
         $this->getJson(route('health'))
@@ -23,6 +28,22 @@ class HealthTest extends TestCase
                     ->has('result', fn (AssertableJson $json) => $json
                         ->hasAll('message', 'state', 'value')
                     )
+                )
+            );
+    }
+
+    public function test_it_includes_consumers_when_authorized()
+    {
+        Sanctum::actingAs(new Consumer(), ['view-consumers']);
+
+        Consumer::create(['name' => 'consumer-1']);
+
+        $this->getJson(route('health'))
+            ->assertOk()
+            ->assertJson(fn (AssertableJson $json) => $json
+                ->hasAll('service', 'checks')
+                ->has('consumers', 1, fn (AssertableJson $json) => $json
+                    ->where('name', 'consumer-1')
                 )
             );
     }

--- a/tests/Health/FailedJobsCheckTest.php
+++ b/tests/Health/FailedJobsCheckTest.php
@@ -14,7 +14,7 @@ class FailedJobsCheckTest extends TestCase
     {
         parent::setUp();
 
-        config(['queue.failed.database' => 'sqlite']);
+        config(['queue.failed.database' => 'default']);
 
         Schema::create(config('queue.failed.table'), fn($table) => $table->id());
     }

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -90,6 +90,7 @@ class ServiceProviderTest extends TestCase
     public function test_gate_abilities()
     {
         $this->assertTrue(Gate::has('graphql'));
+        $this->assertTrue(Gate::has('view-consumers'));
     }
 
     public function test_application_config_merges_butler_service_config()
@@ -185,6 +186,7 @@ class ServiceProviderTest extends TestCase
             ['butler.service.routes.front', '/'],
             ['butler.service.routes.graphql', '/graphql'],
             ['butler.service.routes.health', '/health'],
+            ['butler.service.routes.consumers', '/consumers'],
             ['butler.service.health.checks', [TestCheck::class]],
             ['butler.service.extra.config', [
                 'app.timezone' => 'Europe/Stockholm',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -20,6 +20,19 @@ abstract class TestCase extends AbstractPackageTestCase
         static::createRequiredTestFiles($appPath);
     }
 
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app->config->set('database.default', 'default');
+        $app->config->set('database.connections', [
+            'default' => [
+                'driver'   => 'sqlite',
+                'database' => ':memory:',
+            ]
+        ]);
+    }
+
     protected function getServiceProviderClass()
     {
         return ServiceProvider::class;

--- a/tests/config/butler.php
+++ b/tests/config/butler.php
@@ -37,6 +37,7 @@ return [
             'front' => '/',
             'graphql' => '/graphql',
             'health' => '/health',
+            'consumers' => '/consumers',
         ],
 
         'health' => [


### PR DESCRIPTION
Alternatively include consumers in the `/health` endpoint, if authorized.