### PR TITLE
Dont type hint Consumer in 'graphql' gate ability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Don't type hint `$user` in 'graphql' gate ability
 
 ## [0.9.0] - 2021-04-08
 


### PR DESCRIPTION
Should not be breaking.
Allows other "users" to be granted graphql abilities.