### PR TITLE
Add configuration option for TrustProxies middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Configuration option for TrustProxies middleware.
 
 ## [0.15.0] - 2021-11-23
 

--- a/src/Http/Kernel.php
+++ b/src/Http/Kernel.php
@@ -14,7 +14,7 @@ abstract class Kernel extends HttpKernel
      * @var array
      */
     protected $middleware = [
-        \Illuminate\Http\Middleware\TrustProxies::class,
+        \Butler\Service\Http\Middleware\TrustProxies::class,
         \Fruitcake\Cors\HandleCors::class,
         \Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,

--- a/src/Http/Middleware/TrustProxies.php
+++ b/src/Http/Middleware/TrustProxies.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Butler\Service\Http\Middleware;
+
+use Illuminate\Http\Middleware\TrustProxies as Middleware;
+
+class TrustProxies extends Middleware
+{
+    protected function proxies()
+    {
+        return config('trustedproxy.proxies');
+    }
+}

--- a/tests/Middleware/TrustProxiesTest.php
+++ b/tests/Middleware/TrustProxiesTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Butler\Service\Tests\Middleware;
+
+use Butler\Service\Http\Middleware\TrustProxies;
+use Butler\Service\Tests\TestCase;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class TrustProxiesTest extends TestCase
+{
+    public function test_middleware()
+    {
+        config(['trustedproxy.proxies' => '1.2.3.4']);
+
+        $request = Request::create('/');
+
+        (new TrustProxies())->handle($request, fn() => new Response());
+
+        $this->assertEquals(['1.2.3.4'], $request->getTrustedProxies());
+    }
+}


### PR DESCRIPTION
Laravel implemented its own [TrustProxies](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Http/Middleware/TrustProxies.php)-middleware instead of using "fideloper/TrustedProxy", and with that change the possibility to configure the middleware with the `trustedproxy.proxies` config option was left out.