### PR TITLE
Add 'laravelOctane' and 'runningOctane' to health custom application data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added "laravelOctane" and "runningOctane" to health custom application data.
 
 ## [0.18.1] - 2022-03-15
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -131,6 +131,8 @@ class ServiceProvider extends BaseServiceProvider
     {
         HealthRepository::customApplicationData(fn () => [
             'butlerService' => ltrim(InstalledVersions::getPrettyVersion('glesys/butler-service'), 'v'),
+            'laravelOctane' => ltrim(InstalledVersions::getPrettyVersion('laravel/octane'), 'v'),
+            'runningOctane' => (int) getenv('LARAVEL_OCTANE') === 1,
         ]);
 
         if ($this->app->configurationIsCached()) {

--- a/tests/Feature/HealthTest.php
+++ b/tests/Feature/HealthTest.php
@@ -15,7 +15,16 @@ class HealthTest extends TestCase
             ->assertOk()
             ->assertJson(fn (AssertableJson $json) => $json
                 ->has('application', fn (AssertableJson $json) => $json
-                    ->hasAll('name', 'timezone', 'php', 'laravel', 'butlerHealth', 'butlerService')
+                    ->hasAll(
+                        'name',
+                        'timezone',
+                        'php',
+                        'laravel',
+                        'laravelOctane',
+                        'runningOctane',
+                        'butlerHealth',
+                        'butlerService',
+                    )
                 )
                 ->has('checks', 4, fn (AssertableJson $json) => $json
                     ->hasAll('name', 'slug', 'group', 'description')


### PR DESCRIPTION
To determine (from the health route) if the service is running octane or not and what version.

```json
{
    "application": {
        "name": "Example service",
        "timezone": "UTC",
        "php": "8.0.16",
        "laravel": "9.4.1",
        "butlerHealth": "0.2.1",
        "butlerService": "dev-master",
        "laravelOctane": "1.2.4",
        "runningOctane": true
    },
    "checks": []
}
```