### PR TITLE
Add method fromArray and fromConfig to graphql client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Method `fromArray` and `fromConfig` to graphql client.
 
 ## [0.22.3] - 2023-05-22
 

--- a/src/Graphql/Client.php
+++ b/src/Graphql/Client.php
@@ -15,6 +15,18 @@ class Client
     ) {
     }
 
+    public static function fromArray(array $array): static
+    {
+        return isset($array['timeout'])
+            ? new static($array['url'], $array['token'], $array['timeout'])
+            : new static($array['url'], $array['token']);
+    }
+
+    public static function fromConfig(string $configKey): static
+    {
+        return static::fromArray(config($configKey));
+    }
+
     public function request(string $query, array $variables = [])
     {
         $response = Http::withToken($this->token)

--- a/tests/Graphql/ClientTest.php
+++ b/tests/Graphql/ClientTest.php
@@ -10,6 +10,33 @@ use Illuminate\Support\Facades\Http;
 
 class ClientTest extends TestCase
 {
+    public function test_fromArray()
+    {
+        $arrayWithoutTimeout = [
+            'url' => 'localhost',
+            'token' => 'secret',
+        ];
+
+        $arrayWithTimeout = [
+            'url' => 'localhost',
+            'token' => 'secret',
+            'timeout' => 3,
+        ];
+
+        $this->assertInstanceOf(Client::class, Client::fromArray($arrayWithoutTimeout));
+        $this->assertInstanceOf(Client::class, Client::fromArray($arrayWithTimeout));
+    }
+
+    public function test_fromConfig()
+    {
+        config(['services.example-service' => [
+            'url' => 'localhost',
+            'token' => 'secret',
+        ]]);
+
+        $this->assertInstanceOf(Client::class, Client::fromConfig('services.example-service'));
+    }
+
     public function test_request_happy_path()
     {
         Http::fakeSequence()->push(['data' => 'foobar']);


### PR DESCRIPTION
```php
// before
$this->app->when(ExampleService::class)
    ->needs(GraphqlClient::class)
    ->give(fn () => new GraphqlClient(
        config('services.example.service.url'),
        config('services.example-service.token'),
    ));

// after
$this->app->when(ExampleService::class)
    ->needs(GraphqlClient::class)
    ->give(fn () => GraphqlClient::fromConfig('services.example-service'));
```