### PR TITLE
Add test helper class "ServiceTestCase"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Assertion in 'assertGraphqlSent' helper.
 - Loading spinner.
+- Test helper class `ServiceTestCase`.
 
 ## [0.25.0] - 2024-02-05
 

--- a/src/Testing/Graphql/Query.php
+++ b/src/Testing/Graphql/Query.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butler\Service\Testing\Graphql;
+
+use Closure;
+
+class Query
+{
+    public int $httpResponseStatus = 200;
+    public mixed $httpResponseBody = ['data' => 'payload'];
+
+    public mixed $expectedResult = 'payload';
+    public mixed $expectedResultOnException = null;
+
+    public ?string $expectedQuery = null;
+    public array $expectedVariables = [];
+
+    public bool $shouldHandleException = true;
+
+    public static function test(Closure $callback): static
+    {
+        return new static($callback);
+    }
+
+    public function __construct(public readonly Closure $callback)
+    {
+    }
+
+    public function returns(mixed $expectedResult): static
+    {
+        $this->expectedResult = $expectedResult;
+
+        return $this;
+    }
+
+    public function sends(string $expectedQuery, array $expectedVariables = []): static
+    {
+        throw_unless(is_graphql($expectedQuery), 'Expected query is not a valid GraphQL query.');
+
+        $this->expectedQuery = $expectedQuery;
+        $this->expectedVariables = $expectedVariables;
+
+        return $this;
+    }
+
+    public function receives(mixed $httpResponseBody, ?int $httpResponseStatus = null): static
+    {
+        $this->httpResponseBody = $httpResponseBody;
+
+        if ($httpResponseStatus) {
+            $this->httpResponseStatus = $httpResponseStatus;
+        }
+
+        return $this;
+    }
+
+    public function throwsExceptionOnErrors(): static
+    {
+        $this->shouldHandleException = false;
+
+        return $this;
+    }
+
+    public function run(): mixed
+    {
+        return ($this->callback)();
+    }
+}

--- a/src/Testing/Graphql/ServiceTestCase.php
+++ b/src/Testing/Graphql/ServiceTestCase.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butler\Service\Testing\Graphql;
+
+use Butler\Service\Graphql\Service;
+use Butler\Service\Testing\TestCase;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionClass;
+use RuntimeException;
+
+abstract class ServiceTestCase extends TestCase
+{
+    protected ?string $serviceClass = null;
+
+    abstract public static function queryProvider();
+
+    public function service(): Service
+    {
+        return new ($this->serviceClass ?? $this->guessServiceClass());
+    }
+
+    public function guessServiceClass(): string
+    {
+        $testClassName = str(basename((new ReflectionClass($this))->getFileName()))
+            ->remove('Test.php');
+
+        $this->serviceClass = class_exists('App\\Services\\' . $testClassName)
+            ? 'App\\Services\\' . $testClassName
+            : 'App\\' . $testClassName;
+
+        return $this->serviceClass;
+    }
+
+    public function test_request_is_sent_correctly()
+    {
+        $service = $this->service();
+
+        $this->assertNotEmpty($service->url);
+        $this->assertNotEmpty($service->token);
+
+        Http::preventStrayRequests()->fake([
+            $this->service()->url => ['data' => ['__typename' => 'Query']],
+        ]);
+
+        $this->assertEquals(['__typename' => 'Query'], $service->request('{ __typename }'));
+
+        $this->assertGraphqlSent(
+            fn ($request) => $request->hasHeader('Authorization', "Bearer {$service->token}")
+        );
+    }
+
+    #[DataProvider('queryProvider')]
+    public function test_query_happy_path(Query $query)
+    {
+        Http::preventStrayRequests()->fake([
+            $this->service()->url => Http::response(
+                $query->httpResponseBody,
+                $query->httpResponseStatus,
+            ),
+        ]);
+
+        $result = $query->run();
+
+        if (is_callable($query->expectedResult)) {
+            $this->assertTrue(($query->expectedResult)($result));
+        } else {
+            $this->assertSame($query->expectedResult, $result);
+        }
+
+        if ($query->expectedQuery || $query->expectedVariables) {
+            $this->assertGraphqlSent(
+                query: $query->expectedQuery ?: null,
+                variables: $query->expectedVariables ?: [],
+            );
+        }
+    }
+
+    #[DataProvider('queryProvider')]
+    public function test_query_handles_graphql_error(Query $query): void
+    {
+        if (! $query->shouldHandleException) {
+            $this->expectException(RuntimeException::class);
+        }
+
+        Http::preventStrayRequests()->fake([
+            $this->service()->url => ['not-data' => []],
+        ]);
+
+        $result = $query->run();
+
+        if ($result instanceof Collection) {
+            $this->assertTrue($result->isEmpty());
+        } else {
+            $this->assertSame($query->expectedResultOnException, $result);
+        }
+    }
+
+    #[DataProvider('queryProvider')]
+    public function test_query_handles_http_server_error(Query $query): void
+    {
+        if (! $query->shouldHandleException) {
+            $this->expectException(RequestException::class);
+        }
+
+        Http::preventStrayRequests()->fake([
+            $this->service()->url => Http::response('Server error', 500),
+        ]);
+
+        $result = $query->run();
+
+        if ($result instanceof Collection) {
+            $this->assertTrue($result->isEmpty());
+        } else {
+            $this->assertSame($query->expectedResultOnException, $result);
+        }
+    }
+}

--- a/tests/Testing/Graphql/ServiceTestCaseTest.php
+++ b/tests/Testing/Graphql/ServiceTestCaseTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butler\Service\Tests\Testing\Graphql;
+
+use Butler\Service\Graphql\Service;
+use Butler\Service\Testing\Graphql\Query;
+use Butler\Service\Testing\Graphql\ServiceTestCase;
+use Butler\Service\Tests\TestCase;
+use Illuminate\Support\Arr;
+
+class ServiceTestCaseTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['services.dummy-service' => [
+            'url' => 'http://localhost/graphql',
+            'token' => 'secret',
+        ]]);
+    }
+
+    public function test_service()
+    {
+        $this->assertInstanceOf(DummyService::class, $this->dummyTest()->service());
+    }
+
+    public function test_guessServiceClass()
+    {
+        $this->assertEquals('App\ServiceTestCase', $this->dummyTest()->guessServiceClass());
+    }
+
+    private function dummyTest(): object
+    {
+        return new class('dummyTest') extends ServiceTestCase
+        {
+            protected ?string $serviceClass = DummyService::class;
+
+            public static function queryProvider()
+            {
+                return [
+                    'normalQuery' => [
+                        Query::test(fn () => (new DummyService())->normalQuery())
+                            ->sends('{ foo }')
+                            ->receives(Arr::undot(['data.bar' => 'baz']))
+                            ->returns('baz'),
+                    ],
+                    'variables' => [
+                        Query::test(fn () => (new DummyService())->queryWithVariables())
+                            ->sends('{ foo }', ['bar' => 'baz'])
+                            ->receives(Arr::undot(['data.foo' => 'baz']))
+                            ->returns('baz'),
+                    ],
+                    'normalCollect' => [
+                        Query::test(fn () => (new DummyService())->normalCollect())
+                            ->sends('{ foobars }')
+                            ->receives(Arr::undot(['data.foobars' => ['foo1', 'foo2']]))
+                            ->returns(fn ($result) => $result->toArray() === ['foo1', 'foo2']),
+                    ],
+                    'normalRequest' => [
+                        Query::test(fn () => (new DummyService())->normalRequest())
+                            ->sends('{ foo }')
+                            ->receives(Arr::undot(['data.foo' => 'baz']))
+                            ->returns(['foo' => 'baz'])
+                            ->throwsExceptionOnErrors(),
+                    ],
+                ];
+            }
+        };
+    }
+}
+
+class DummyService extends Service
+{
+    public function normalQuery(): mixed
+    {
+        return $this->query('{ foo { bar } }', key: 'bar');
+    }
+
+    public function queryWithVariables(): mixed
+    {
+        return $this->query('{ foo { bar } }', ['bar' => 'baz'], 'bar');
+    }
+
+    public function normalCollect(): mixed
+    {
+        return $this->collect('{ foobars }');
+    }
+
+    public function normalRequest(): mixed
+    {
+        return $this->request('{ foo }');
+    }
+}


### PR DESCRIPTION
Example:

```php
class DummyServiceTest extends ServiceTestCase
{
    public static function queryProvider()
    {
        return [
            'normalQuery' => [
                Query::test(fn () => (new DummyService())->normalQuery())
                    ->sends('{ foo }')
                    ->receives(Arr::undot(['data.bar' => 'baz']))
                    ->returns('baz'),
            ],
        ];
    }
}
```