### PR TITLE
Add explicit table name for Consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Add explicit table name to `Consumer` to prevent implicit lookup through pluralization.
+
 
 ## [0.29.0] - 2025-08-14
 

--- a/src/Models/Consumer.php
+++ b/src/Models/Consumer.php
@@ -14,4 +14,6 @@ class Consumer extends Model implements AuthenticatableContract, HasAccessTokens
 {
     use Authenticatable;
     use HasAccessTokens;
+
+    protected $table = 'consumers';
 }


### PR DESCRIPTION
This is to prevent implicit table name lookup through the `Illuminate\Support\Pluralizer` flow which adds unnecessary milliseconds to every request.